### PR TITLE
Migrate from PostgreSQL to MySQL

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -28,9 +28,9 @@ This guide will help you migrate the TJTMS application from Render's PostgreSQL 
 
 ## Step 2: Install Required Dependencies
 
-1. Install the MySQL client for Python:
+1. Install PyMySQL for Python:
    ```bash
-   pip install mysqlclient
+   pip install PyMySQL
    ```
    
    Or install all requirements:
@@ -136,3 +136,12 @@ If you have any media files (attachments) in your Render deployment, make sure t
 4. **Character Encoding Issues**:
    - Ensure your MySQL database is using utf8mb4 encoding
    - Check that the data was properly encoded in the original database
+
+### PyMySQL vs mysqlclient
+
+This project uses PyMySQL instead of mysqlclient because:
+- It's a pure Python package, so it doesn't require any C compiler or MySQL development headers
+- It's easier to install on various platforms
+- It provides similar functionality to mysqlclient
+
+If you encounter any performance issues, you might consider switching to mysqlclient which is generally faster but requires more complex installation.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -32,7 +32,37 @@ This guide will help you migrate the TJTMS application from Render's PostgreSQL 
    pip install -r requirements.txt
    ```
 
-## Step 3: Migrate the Data
+## Step 3: Configure Environment Variables
+
+The application now supports switching between PostgreSQL and MySQL using environment variables. To use MySQL:
+
+1. Set the `DATABASE_TYPE` environment variable to `mysql`:
+
+   **On Windows (Command Prompt):**
+   ```cmd
+   set DATABASE_TYPE=mysql
+   ```
+
+   **On Windows (PowerShell):**
+   ```powershell
+   $env:DATABASE_TYPE = "mysql"
+   ```
+
+   **On macOS/Linux:**
+   ```bash
+   export DATABASE_TYPE=mysql
+   ```
+
+2. Optionally, you can customize other database settings:
+   ```bash
+   export DB_NAME=juice_task_db
+   export DB_USER=root
+   export DB_PASSWORD=Aamruth@22
+   export DB_HOST=localhost
+   export DB_PORT=3306
+   ```
+
+## Step 4: Migrate the Data
 
 There are two approaches to migrate the data. Choose the one that works best for you:
 
@@ -48,18 +78,13 @@ There are two approaches to migrate the data. Choose the one that works best for
    psql temp_juice_db < juice_db_backup.sql
    ```
 
-3. Temporarily modify settings.py to use the local PostgreSQL database:
-   ```python
-   DATABASES = {
-       'default': {
-           'ENGINE': 'django.db.backends.postgresql',
-           'NAME': 'temp_juice_db',
-           'USER': 'postgres',
-           'PASSWORD': 'your_postgres_password',
-           'HOST': 'localhost',
-           'PORT': '5432',
-       }
-   }
+3. Temporarily ensure you're using PostgreSQL (unset the DATABASE_TYPE variable):
+   ```bash
+   # On Windows
+   set DATABASE_TYPE=
+   
+   # On macOS/Linux
+   unset DATABASE_TYPE
    ```
 
 4. Create a JSON fixture of all data:
@@ -67,7 +92,14 @@ There are two approaches to migrate the data. Choose the one that works best for
    python manage.py dumpdata --exclude contenttypes --exclude auth.permission > all_data.json
    ```
 
-5. Switch back to the MySQL configuration (already done in this branch)
+5. Switch to MySQL:
+   ```bash
+   # On Windows
+   set DATABASE_TYPE=mysql
+   
+   # On macOS/Linux
+   export DATABASE_TYPE=mysql
+   ```
 
 6. Run migrations to create the schema in MySQL:
    ```bash
@@ -85,7 +117,7 @@ This approach is more complex and may require manual adjustments to the SQL:
 
 1. Use a tool like [pgloader](https://github.com/dimitri/pgloader) to migrate directly:
    ```bash
-   pgloader postgresql://juice_db_drbd_user:XrWKZI7n0vehFTaQ22PTYYo3krPrOE7h@dpg-d02kg93e5dus73bt74ng-a.oregon-postgres.render.com/juice_db_drbd mysql://root:@localhost/juice_task_db
+   pgloader postgresql://juice_db_drbd_user:XrWKZI7n0vehFTaQ22PTYYo3krPrOE7h@dpg-d02kg93e5dus73bt74ng-a.oregon-postgres.render.com/juice_db_drbd mysql://root:Aamruth@22@localhost/juice_task_db
    ```
 
    Or use a conversion script like [pg2mysql](https://github.com/ChrisLundquist/pg2mysql) to convert the dump:
@@ -94,23 +126,50 @@ This approach is more complex and may require manual adjustments to the SQL:
    mysql -u root -p juice_task_db < mysql_dump.sql
    ```
 
-## Step 4: Test the Application
+## Step 5: Test the Application
 
-1. Run the Django development server:
+1. Ensure the DATABASE_TYPE environment variable is set to mysql:
+   ```bash
+   # On Windows
+   set DATABASE_TYPE=mysql
+   
+   # On macOS/Linux
+   export DATABASE_TYPE=mysql
+   ```
+
+2. Run the Django development server:
    ```bash
    python manage.py runserver
    ```
 
-2. Visit http://127.0.0.1:8000/ in your browser
+3. Visit http://127.0.0.1:8000/ in your browser
 
-3. Test all functionality to ensure the migration was successful
+4. Test all functionality to ensure the migration was successful
 
-## Step 5: Copy Media Files
+## Step 6: Copy Media Files
 
 If you have any media files (attachments) in your Render deployment, make sure to copy them to your local environment:
 
 1. Download the files from Render
 2. Place them in the appropriate directory (e.g., `media/attachments/`)
+
+## Making the Environment Variable Permanent
+
+To avoid setting the environment variable each time, you can:
+
+### On Windows:
+
+1. Set a system environment variable:
+   - Right-click on "This PC" or "My Computer"
+   - Select "Properties" > "Advanced system settings" > "Environment Variables"
+   - Add a new variable with name `DATABASE_TYPE` and value `mysql`
+
+### On macOS/Linux:
+
+1. Add to your shell profile file (~/.bashrc, ~/.zshrc, etc.):
+   ```bash
+   export DATABASE_TYPE=mysql
+   ```
 
 ## Troubleshooting
 
@@ -118,7 +177,7 @@ If you have any media files (attachments) in your Render deployment, make sure t
 
 1. **MySQL Connection Errors**:
    - Ensure MySQL server is running
-   - Verify username and password in settings.py
+   - Verify username and password in settings.py or environment variables
    - Check that the database exists
 
 2. **Migration Errors**:

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -14,6 +14,7 @@ This guide will help you migrate the TJTMS application from Render's PostgreSQL 
    ```bash
    mysql -u root -p
    ```
+   (Enter your password: `Aamruth@22`)
 
 2. Create a new database:
    ```sql
@@ -29,40 +30,15 @@ This guide will help you migrate the TJTMS application from Render's PostgreSQL 
 
 1. Install the MySQL client for Python:
    ```bash
+   pip install mysqlclient
+   ```
+   
+   Or install all requirements:
+   ```bash
    pip install -r requirements.txt
    ```
 
-## Step 3: Configure Environment Variables
-
-The application now supports switching between PostgreSQL and MySQL using environment variables. To use MySQL:
-
-1. Set the `DATABASE_TYPE` environment variable to `mysql`:
-
-   **On Windows (Command Prompt):**
-   ```cmd
-   set DATABASE_TYPE=mysql
-   ```
-
-   **On Windows (PowerShell):**
-   ```powershell
-   $env:DATABASE_TYPE = "mysql"
-   ```
-
-   **On macOS/Linux:**
-   ```bash
-   export DATABASE_TYPE=mysql
-   ```
-
-2. Optionally, you can customize other database settings:
-   ```bash
-   export DB_NAME=juice_task_db
-   export DB_USER=root
-   export DB_PASSWORD=Aamruth@22
-   export DB_HOST=localhost
-   export DB_PORT=3306
-   ```
-
-## Step 4: Migrate the Data
+## Step 3: Migrate the Data
 
 There are two approaches to migrate the data. Choose the one that works best for you:
 
@@ -78,13 +54,18 @@ There are two approaches to migrate the data. Choose the one that works best for
    psql temp_juice_db < juice_db_backup.sql
    ```
 
-3. Temporarily ensure you're using PostgreSQL (unset the DATABASE_TYPE variable):
-   ```bash
-   # On Windows
-   set DATABASE_TYPE=
-   
-   # On macOS/Linux
-   unset DATABASE_TYPE
+3. Temporarily modify settings.py to use the local PostgreSQL database:
+   ```python
+   DATABASES = {
+       'default': {
+           'ENGINE': 'django.db.backends.postgresql',
+           'NAME': 'temp_juice_db',
+           'USER': 'postgres',
+           'PASSWORD': 'your_postgres_password',
+           'HOST': 'localhost',
+           'PORT': '5432',
+       }
+   }
    ```
 
 4. Create a JSON fixture of all data:
@@ -92,14 +73,7 @@ There are two approaches to migrate the data. Choose the one that works best for
    python manage.py dumpdata --exclude contenttypes --exclude auth.permission > all_data.json
    ```
 
-5. Switch to MySQL:
-   ```bash
-   # On Windows
-   set DATABASE_TYPE=mysql
-   
-   # On macOS/Linux
-   export DATABASE_TYPE=mysql
-   ```
+5. Change back to the MySQL configuration (already done in this branch)
 
 6. Run migrations to create the schema in MySQL:
    ```bash
@@ -126,50 +100,23 @@ This approach is more complex and may require manual adjustments to the SQL:
    mysql -u root -p juice_task_db < mysql_dump.sql
    ```
 
-## Step 5: Test the Application
+## Step 4: Test the Application
 
-1. Ensure the DATABASE_TYPE environment variable is set to mysql:
-   ```bash
-   # On Windows
-   set DATABASE_TYPE=mysql
-   
-   # On macOS/Linux
-   export DATABASE_TYPE=mysql
-   ```
-
-2. Run the Django development server:
+1. Run the Django development server:
    ```bash
    python manage.py runserver
    ```
 
-3. Visit http://127.0.0.1:8000/ in your browser
+2. Visit http://127.0.0.1:8000/ in your browser
 
-4. Test all functionality to ensure the migration was successful
+3. Test all functionality to ensure the migration was successful
 
-## Step 6: Copy Media Files
+## Step 5: Copy Media Files
 
 If you have any media files (attachments) in your Render deployment, make sure to copy them to your local environment:
 
 1. Download the files from Render
 2. Place them in the appropriate directory (e.g., `media/attachments/`)
-
-## Making the Environment Variable Permanent
-
-To avoid setting the environment variable each time, you can:
-
-### On Windows:
-
-1. Set a system environment variable:
-   - Right-click on "This PC" or "My Computer"
-   - Select "Properties" > "Advanced system settings" > "Environment Variables"
-   - Add a new variable with name `DATABASE_TYPE` and value `mysql`
-
-### On macOS/Linux:
-
-1. Add to your shell profile file (~/.bashrc, ~/.zshrc, etc.):
-   ```bash
-   export DATABASE_TYPE=mysql
-   ```
 
 ## Troubleshooting
 
@@ -177,7 +124,7 @@ To avoid setting the environment variable each time, you can:
 
 1. **MySQL Connection Errors**:
    - Ensure MySQL server is running
-   - Verify username and password in settings.py or environment variables
+   - Verify username and password in settings.py
    - Check that the database exists
 
 2. **Migration Errors**:
@@ -189,7 +136,3 @@ To avoid setting the environment variable each time, you can:
 4. **Character Encoding Issues**:
    - Ensure your MySQL database is using utf8mb4 encoding
    - Check that the data was properly encoded in the original database
-
-### Need Help?
-
-If you encounter any issues during the migration process, please create an issue in the repository or contact the development team.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,0 +1,136 @@
+# PostgreSQL to MySQL Migration Guide
+
+This guide will help you migrate the TJTMS application from Render's PostgreSQL database to a local MySQL server.
+
+## Prerequisites
+
+- MySQL server installed and running
+- Python 3.x installed
+- Git installed
+
+## Step 1: Set up the MySQL Database
+
+1. Log in to MySQL:
+   ```bash
+   mysql -u root -p
+   ```
+
+2. Create a new database:
+   ```sql
+   CREATE DATABASE juice_task_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+   ```
+
+3. Exit MySQL:
+   ```sql
+   EXIT;
+   ```
+
+## Step 2: Install Required Dependencies
+
+1. Install the MySQL client for Python:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Step 3: Migrate the Data
+
+There are two approaches to migrate the data. Choose the one that works best for you:
+
+### Option A: Using Django's Migration System (Recommended)
+
+1. Set up a temporary PostgreSQL database locally:
+   ```bash
+   createdb temp_juice_db
+   ```
+
+2. Import the PostgreSQL dump:
+   ```bash
+   psql temp_juice_db < juice_db_backup.sql
+   ```
+
+3. Temporarily modify settings.py to use the local PostgreSQL database:
+   ```python
+   DATABASES = {
+       'default': {
+           'ENGINE': 'django.db.backends.postgresql',
+           'NAME': 'temp_juice_db',
+           'USER': 'postgres',
+           'PASSWORD': 'your_postgres_password',
+           'HOST': 'localhost',
+           'PORT': '5432',
+       }
+   }
+   ```
+
+4. Create a JSON fixture of all data:
+   ```bash
+   python manage.py dumpdata --exclude contenttypes --exclude auth.permission > all_data.json
+   ```
+
+5. Switch back to the MySQL configuration (already done in this branch)
+
+6. Run migrations to create the schema in MySQL:
+   ```bash
+   python manage.py migrate
+   ```
+
+7. Load the fixture into MySQL:
+   ```bash
+   python manage.py loaddata all_data.json
+   ```
+
+### Option B: Using a Direct SQL Conversion
+
+This approach is more complex and may require manual adjustments to the SQL:
+
+1. Use a tool like [pgloader](https://github.com/dimitri/pgloader) to migrate directly:
+   ```bash
+   pgloader postgresql://juice_db_drbd_user:XrWKZI7n0vehFTaQ22PTYYo3krPrOE7h@dpg-d02kg93e5dus73bt74ng-a.oregon-postgres.render.com/juice_db_drbd mysql://root:@localhost/juice_task_db
+   ```
+
+   Or use a conversion script like [pg2mysql](https://github.com/ChrisLundquist/pg2mysql) to convert the dump:
+   ```bash
+   pg2mysql juice_db_backup.sql > mysql_dump.sql
+   mysql -u root -p juice_task_db < mysql_dump.sql
+   ```
+
+## Step 4: Test the Application
+
+1. Run the Django development server:
+   ```bash
+   python manage.py runserver
+   ```
+
+2. Visit http://127.0.0.1:8000/ in your browser
+
+3. Test all functionality to ensure the migration was successful
+
+## Step 5: Copy Media Files
+
+If you have any media files (attachments) in your Render deployment, make sure to copy them to your local environment:
+
+1. Download the files from Render
+2. Place them in the appropriate directory (e.g., `media/attachments/`)
+
+## Troubleshooting
+
+### Common Issues
+
+1. **MySQL Connection Errors**:
+   - Ensure MySQL server is running
+   - Verify username and password in settings.py
+   - Check that the database exists
+
+2. **Migration Errors**:
+   - If you encounter errors during `python manage.py migrate`, try running `python manage.py makemigrations` first
+
+3. **Data Import Issues**:
+   - If you have issues with the JSON fixture, try excluding problematic apps: `python manage.py dumpdata --exclude contenttypes --exclude auth.permission --exclude sessions > all_data.json`
+
+4. **Character Encoding Issues**:
+   - Ensure your MySQL database is using utf8mb4 encoding
+   - Check that the data was properly encoded in the original database
+
+### Need Help?
+
+If you encounter any issues during the migration process, please create an issue in the repository or contact the development team.

--- a/juice_task/settings.py
+++ b/juice_task/settings.py
@@ -12,6 +12,8 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 
 import os
 from pathlib import Path
+import pymysql
+pymysql.install_as_MySQLdb()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -78,11 +80,11 @@ WSGI_APPLICATION = "juice_task.wsgi.application"
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'juice_task_db',  # Your database name
-        'USER': 'root',           # Your MySQL username
-        'PASSWORD': 'Aamruth@22', # Password you just set
-        'HOST': 'localhost',      # Host where MySQL is running
-        'PORT': '3306',           # Default MySQL port
+        'NAME': 'juice_task_db',
+        'USER': 'root',
+        'PASSWORD': 'Aamruth@22',
+        'HOST': 'localhost',
+        'PORT': '3306',
         'OPTIONS': {
             'charset': 'utf8mb4',
             'init_command': "SET sql_mode='STRICT_TRANS_TABLES'"

--- a/juice_task/settings.py
+++ b/juice_task/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 
 import os
-# import dj_database_url  # Commented out as we're not using dj_database_url for MySQL
+import dj_database_url
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -76,21 +76,28 @@ WSGI_APPLICATION = "juice_task.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
-# Updated to use MySQL instead of PostgreSQL
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'juice_task_db',  # Your MySQL database name
-        'USER': 'root',           # Your MySQL username
-        'PASSWORD': '',           # Your MySQL password (empty for development)
-        'HOST': 'localhost',      # MySQL server address
-        'PORT': '3306',           # MySQL default port
-        'OPTIONS': {
-            'charset': 'utf8mb4',
-            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
-        },
-    }
-}
+def get_database_config():
+    if os.environ.get('DATABASE_TYPE') == 'mysql':
+        return {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': os.environ.get('DB_NAME', 'juice_task_db'),
+            'USER': os.environ.get('DB_USER', 'root'),
+            'PASSWORD': os.environ.get('DB_PASSWORD', 'Aamruth@22'),
+            'HOST': os.environ.get('DB_HOST', 'localhost'),
+            'PORT': os.environ.get('DB_PORT', '3306'),
+            'OPTIONS': {
+                'charset': 'utf8mb4',
+                'init_command': "SET sql_mode='STRICT_TRANS_TABLES'"
+            }
+        }
+    else:
+        return dj_database_url.config(
+            default='postgresql://juice_db_drbd_user:XrWKZI7n0vehFTaQ22PTYYo3krPrOE7h@dpg-d02kg93e5dus73bt74ng-a.oregon-postgres.render.com/juice_db_drbd',
+            conn_max_age=600,
+            ssl_require=not DEBUG
+        )
+
+DATABASES = {'default': get_database_config()}
 
 
 # Password validation

--- a/juice_task/settings.py
+++ b/juice_task/settings.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 
 import os
-import dj_database_url
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -76,28 +75,20 @@ WSGI_APPLICATION = "juice_task.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
-def get_database_config():
-    if os.environ.get('DATABASE_TYPE') == 'mysql':
-        return {
-            'ENGINE': 'django.db.backends.mysql',
-            'NAME': os.environ.get('DB_NAME', 'juice_task_db'),
-            'USER': os.environ.get('DB_USER', 'root'),
-            'PASSWORD': os.environ.get('DB_PASSWORD', 'Aamruth@22'),
-            'HOST': os.environ.get('DB_HOST', 'localhost'),
-            'PORT': os.environ.get('DB_PORT', '3306'),
-            'OPTIONS': {
-                'charset': 'utf8mb4',
-                'init_command': "SET sql_mode='STRICT_TRANS_TABLES'"
-            }
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'juice_task_db',  # Your database name
+        'USER': 'root',           # Your MySQL username
+        'PASSWORD': 'Aamruth@22', # Password you just set
+        'HOST': 'localhost',      # Host where MySQL is running
+        'PORT': '3306',           # Default MySQL port
+        'OPTIONS': {
+            'charset': 'utf8mb4',
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'"
         }
-    else:
-        return dj_database_url.config(
-            default='postgresql://juice_db_drbd_user:XrWKZI7n0vehFTaQ22PTYYo3krPrOE7h@dpg-d02kg93e5dus73bt74ng-a.oregon-postgres.render.com/juice_db_drbd',
-            conn_max_age=600,
-            ssl_require=not DEBUG
-        )
-
-DATABASES = {'default': get_database_config()}
+    }
+}
 
 
 # Password validation

--- a/juice_task/settings.py
+++ b/juice_task/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 
 import os
-import dj_database_url
+# import dj_database_url  # Commented out as we're not using dj_database_url for MySQL
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -76,12 +76,20 @@ WSGI_APPLICATION = "juice_task.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
+# Updated to use MySQL instead of PostgreSQL
 DATABASES = {
-    'default': dj_database_url.config(
-        default='postgresql://juice_db_drbd_user:XrWKZI7n0vehFTaQ22PTYYo3krPrOE7h@dpg-d02kg93e5dus73bt74ng-a.oregon-postgres.render.com/juice_db_drbd',
-        conn_max_age=600,
-        ssl_require=not DEBUG  # Require SSL in production
-    )
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'juice_task_db',  # Your MySQL database name
+        'USER': 'root',           # Your MySQL username
+        'PASSWORD': '',           # Your MySQL password (empty for development)
+        'HOST': 'localhost',      # MySQL server address
+        'PORT': '3306',           # MySQL default port
+        'OPTIONS': {
+            'charset': 'utf8mb4',
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+        },
+    }
 }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,9 @@ django-celery-beat==2.7.0
 django-timezone-field==7.1
 gunicorn==23.0.0
 kombu==5.3.7
-mysqlclient==2.2.4  # Added MySQL client
 packaging==24.2
 prompt_toolkit==3.0.51
+PyMySQL==1.1.0  # Added PyMySQL instead of mysqlclient
 # psycopg2-binary==2.9.10  # Commented out as we're not using PostgreSQL
 python-crontab==3.2.0
 python-dateutil==2.9.0.post0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,10 @@ django-celery-beat==2.7.0
 django-timezone-field==7.1
 gunicorn==23.0.0
 kombu==5.3.7
+mysqlclient==2.2.4  # Added MySQL client
 packaging==24.2
 prompt_toolkit==3.0.51
-psycopg2-binary==2.9.10
+# psycopg2-binary==2.9.10  # Commented out as we're not using PostgreSQL
 python-crontab==3.2.0
 python-dateutil==2.9.0.post0
 pytz==2025.2


### PR DESCRIPTION
This PR adds the necessary changes to migrate the application from Render's PostgreSQL database to a local MySQL server.

## Changes:
- Updated `settings.py` to use MySQL instead of PostgreSQL
- Added `mysqlclient` to `requirements.txt`
- Created a comprehensive migration guide (MIGRATION_GUIDE.md)

## How to Test:
1. Check out this branch
2. Follow the instructions in MIGRATION_GUIDE.md
3. Verify that the application works with a MySQL database

## Note:
This PR does not actually migrate the data - it only provides the configuration changes and instructions needed to perform the migration.